### PR TITLE
Replace unzip with unzip2.

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -7,7 +7,7 @@ var zlib = require('zlib')
   , fs = require('fs')
   , events = require('events')
   , util = require('util')
-  , unzip = require('unzip')
+  , unzip = require('unzip2')
 
   // we need adm-zip because unzip doesn't support counting entries
 

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
   },
   "license": "BSD",
   "dependencies": {
-    "unzip": "~0.1.7",
-    "pipette": "~0.9.3",
-    "async": "~0.2.9",
     "adm-zip": "~0.4.3",
     "archiver": "0.4.8",
+    "async": "~0.2.9",
     "colors": "~0.6.0-1",
     "merge": "~1.1.1",
+    "pipette": "~0.9.3",
+    "unzip2": "^0.2.5",
     "xmldom": "~0.1.16"
   },
   "devDependencies": {


### PR DESCRIPTION
It seems `unzip` sometimes throws 'invalid signature' errors
at some archives (I encountered at least one odt-file which
failed because of that), `unzip2` seems to work, see for
example
  https://github.com/EvanOxfeld/node-unzip/issues/41
