### PR TITLE
Round the calculated date, so writer can understand it.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -164,5 +164,5 @@ function daysSince1899(date) {
         idiocy.  */
 
     ((julianDay > 2415078.5) ? 1 : 0);
-  return value;
+  return Math.round(value);
 }


### PR DESCRIPTION
In my case, the result of 'value' always was some float, which caused the libreoffice writer on debian stable to show the wrong date.
